### PR TITLE
fix cmake prefix path in build script

### DIFF
--- a/build
+++ b/build
@@ -30,7 +30,7 @@ make "$JOBS" install
 # Clang, LLD we just built from source.
 mkdir -p "$ROOTDIR/out/build-zig-host"
 cd "$ROOTDIR/out/build-zig-host"
-cmake ../../zig -DCMAKE_INSTALL_PREFIX=../host -DCMAKE_PREFIX_PATH=../host -DCMAKE_BUILD_TYPE=Release
+cmake ../../zig -DCMAKE_INSTALL_PREFIX=../host -DCMAKE_PREFIX_PATH=../out/host -DCMAKE_BUILD_TYPE=Release
 make "$JOBS" install
 
 # Now we have Zig as a cross compiler


### PR DESCRIPTION
cmake could not find the correct llvm/clang/lld version

i'm using cmake version 3.17.0